### PR TITLE
feat: Add privacy settings for community posts and announcements

### DIFF
--- a/src/components/modals/Calendar/CreateCalendarModal.tsx
+++ b/src/components/modals/Calendar/CreateCalendarModal.tsx
@@ -25,6 +25,8 @@ import {
   X,
   Tag,
   MapPin,
+  Shield,
+  Eye,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { searchLocations, type LocationSuggestion } from '@/utils/geolocation';
@@ -38,6 +40,7 @@ export interface CalendarEntry {
   description: string;
   category: string;
   location?: string;
+  privacy: 'community' | 'internal';
 }
 
 export interface CreateCalendarFormData {
@@ -50,6 +53,8 @@ export interface CreateCalendarModalProps {
   onClose: () => void;
   onSuccess?: (data: CreateCalendarFormData) => void;
   type?: 'announcement' | 'events';
+  isAdmin?: boolean;
+  isModerator?: boolean;
 }
 
 const INITIAL_FORM_DATA: CreateCalendarFormData = {
@@ -63,6 +68,7 @@ const INITIAL_FORM_DATA: CreateCalendarFormData = {
       description: '',
       category: '',
       location: '',
+      privacy: 'community',
     },
   ],
   isActive: true,
@@ -73,6 +79,8 @@ const CreateCalendarModal: React.FC<CreateCalendarModalProps> = ({
   onClose,
   onSuccess,
   type = 'events',
+  isAdmin = false,
+  isModerator = false,
 }) => {
   const { t } = useTranslation();
   const [formData, setFormData] = useState<CreateCalendarFormData>(INITIAL_FORM_DATA);
@@ -197,6 +205,7 @@ const CreateCalendarModal: React.FC<CreateCalendarModalProps> = ({
           description: '',
           category: '',
           location: '',
+          privacy: 'community',
         },
       ],
     }));
@@ -406,6 +415,46 @@ const CreateCalendarModal: React.FC<CreateCalendarModalProps> = ({
                       )}
                     </div>
                   </div>
+
+                  {/* Privacy Status */}
+                  {(isAdmin || isModerator) && (
+                    <div>
+                      <label className="block text-xs font-bold text-slate-600 mb-1 flex items-center gap-1">
+                        <Shield size={12} />
+                        Privacy Status <span className="text-red-500">*</span>
+                      </label>
+                      <Select 
+                        value={entry.privacy} 
+                        onValueChange={(value: 'community' | 'internal') => handleEntryChange(entry.id, 'privacy', value)}
+                      >
+                        <SelectTrigger className="w-full px-3 py-2 border border-slate-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-teal-500 font-medium text-sm">
+                          <SelectValue placeholder="Select privacy status" />
+                        </SelectTrigger>
+                        <SelectContent className="z-[302]">
+                          <SelectItem value="community" className="cursor-pointer">
+                            <div className="flex items-center gap-2">
+                              <div className="w-2 h-2 rounded-full bg-emerald-500" />
+                              <div className="flex flex-col text-left">
+                                <span className="font-bold text-slate-700">Community</span>
+                                <span className="text-[10px] text-slate-500">Visible to all community members</span>
+                              </div>
+                            </div>
+                          </SelectItem>
+                          <SelectItem value="internal" className="cursor-pointer">
+                            <div className="flex items-center gap-2">
+                              <div className="w-2 h-2 rounded-full bg-rose-500" />
+                              <div className="flex flex-col text-left">
+                                <span className="font-bold text-slate-700">Internal Only</span>
+                                <span className="text-[10px] text-slate-500 italic flex items-center gap-1">
+                                  <Eye size={10} /> Admins & Moderators Only
+                                </span>
+                              </div>
+                            </div>
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
                 </div>
               ))}
             </div>

--- a/src/components/modals/CommunityReport/CommunityReportModal.tsx
+++ b/src/components/modals/CommunityReport/CommunityReportModal.tsx
@@ -26,6 +26,7 @@ import {
   Link as LinkIcon,
   AlertCircle,
   X,
+  Eye,
 } from 'lucide-react';
 import { useAuth } from '@/context/AuthContext';
 import { Modal } from '@/components/ui/Modal/Modal';
@@ -41,6 +42,8 @@ interface CommunityReportModalProps {
   onSuccess?: () => void;
   communityId: string | number;
   reportType?: 'News' | 'Announcement' | 'Event' | 'Discussion';
+  isAdmin?: boolean;
+  isModerator?: boolean;
 }
 
 export const CommunityReportModal: React.FC<CommunityReportModalProps> = ({
@@ -49,6 +52,8 @@ export const CommunityReportModal: React.FC<CommunityReportModalProps> = ({
   onSuccess,
   communityId,
   reportType = 'News',
+  isAdmin = false,
+  isModerator = false,
 }) => {
   const { user } = useAuth();
   const { t } = useTranslation();
@@ -69,6 +74,7 @@ export const CommunityReportModal: React.FC<CommunityReportModalProps> = ({
     type: reportType,
     location: '',
     contactInfo: '',
+    privacy: 'community',
   });
 
   useEffect(() => {
@@ -226,6 +232,7 @@ export const CommunityReportModal: React.FC<CommunityReportModalProps> = ({
         type: reportType,
         location: '',
         contactInfo: '',
+        privacy: 'community',
       });
     } else {
       setError(result.message || 'Failed to create community report');
@@ -310,6 +317,38 @@ export const CommunityReportModal: React.FC<CommunityReportModalProps> = ({
               </SelectContent>
             </Select>
           </div>
+
+          {/* Privacy - Only for admins/moderators */}
+          {(isAdmin || isModerator) && (
+            <div className="space-y-2">
+              <label className="text-sm font-bold text-slate-700 flex items-center gap-2">
+                <Eye className="w-4 h-4 text-teal-600" />
+                Privacy Status
+              </label>
+              <Select 
+                value={formData.privacy} 
+                onValueChange={(value: 'community' | 'internal') => handleInputChange('privacy', value)}
+              >
+                <SelectTrigger className="w-full px-4 py-3 border border-slate-200 rounded-2xl focus:outline-none focus:ring-2 focus:ring-teal-500 bg-slate-50 font-medium text-left">
+                  <SelectValue placeholder="Select visibility" />
+                </SelectTrigger>
+                <SelectContent className="rounded-2xl border-slate-200 shadow-lg bg-white">
+                  <SelectItem value="community">
+                    <div className="flex flex-col gap-0.5">
+                      <span className="font-bold">Community Visibility</span>
+                      <span className="text-[10px] text-slate-500">Visible to all community members</span>
+                    </div>
+                  </SelectItem>
+                  <SelectItem value="internal">
+                    <div className="flex flex-col gap-0.5">
+                      <span className="font-bold">Internal Only</span>
+                      <span className="text-[10px] text-slate-500">Only visible to community admins and moderators</span>
+                    </div>
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          )}
 
           {/* Start Date and End Date */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/src/components/modals/CommunityReport/ReportDetailModal.tsx
+++ b/src/components/modals/CommunityReport/ReportDetailModal.tsx
@@ -1,0 +1,233 @@
+import React, { useState } from 'react';
+import { 
+  Dialog,
+  DialogContent,
+} from '@/components/ui/dialog';
+import { Button, Avatar, ShadcnBadge as Badge } from '@/components/ui';
+import { 
+  MapPin, 
+  Calendar, 
+  Clock, 
+  User, 
+  Phone, 
+  Share2, 
+  ChevronLeft,
+  ChevronRight,
+  Megaphone,
+  Newspaper,
+  Calendar as CalendarIcon,
+  MessageSquare,
+  Heart
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { CommunityPost } from '@/types/community';
+
+export interface ReportDetailModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  report: CommunityPost | null;
+}
+
+const ReportDetailModal: React.FC<ReportDetailModalProps> = ({ isOpen, onClose, report }) => {
+  const [activeImageIndex, setActiveImageIndex] = useState(0);
+
+  if (!report) return null;
+
+  const images = report.images || [];
+  const hasImages = images.length > 0;
+
+  const nextImage = () => {
+    if (hasImages) {
+      setActiveImageIndex((prev) => (prev + 1) % images.length);
+    }
+  };
+
+  const prevImage = () => {
+    if (hasImages) {
+      setActiveImageIndex((prev) => (prev - 1 + images.length) % images.length);
+    }
+  };
+
+  const getTypeIcon = (type: string) => {
+    switch (type?.toLowerCase()) {
+      case 'announcement': return <Megaphone size={16} />;
+      case 'news': return <Newspaper size={16} />;
+      case 'events': return <CalendarIcon size={16} />;
+      default: return <Megaphone size={16} />;
+    }
+  };
+
+  const getTypeStyles = (type: string) => {
+    switch (type?.toLowerCase()) {
+      case 'announcement': return "bg-teal-50 text-teal-600 border-teal-100";
+      case 'news': return "bg-blue-50 text-blue-600 border-blue-100";
+      case 'events': return "bg-purple-50 text-purple-600 border-purple-100";
+      default: return "bg-slate-50 text-slate-600 border-slate-100";
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-4xl p-0 overflow-hidden border-none bg-white rounded-[2.5rem]">
+        <div className="flex flex-col lg:flex-row h-full max-h-[90vh] overflow-y-auto lg:overflow-hidden">
+          {/* Left Side: Image Gallery */}
+          <div className="lg:w-1/2 bg-slate-900 relative group min-h-[300px] lg:min-h-full flex items-center justify-center">
+            {hasImages ? (
+              <>
+                <img 
+                  src={images[activeImageIndex].imageUrl} 
+                  alt={report.title} 
+                  className="w-full h-full object-contain"
+                />
+                
+                {images.length > 1 && (
+                  <>
+                    <button 
+                      onClick={prevImage}
+                      className="absolute left-4 top-1/2 -translate-y-1/2 w-10 h-10 bg-black/20 hover:bg-black/40 text-white rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                    >
+                      <ChevronLeft size={24} />
+                    </button>
+                    <button 
+                      onClick={nextImage}
+                      className="absolute right-4 top-1/2 -translate-y-1/2 w-10 h-10 bg-black/20 hover:bg-black/40 text-white rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                    >
+                      <ChevronRight size={24} />
+                    </button>
+                    
+                    <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-1.5 px-3 py-1.5 bg-black/20 rounded-full">
+                      {images.map((_, idx) => (
+                        <div 
+                          key={idx} 
+                          className={cn(
+                            "w-1.5 h-1.5 rounded-full transition-all",
+                            idx === activeImageIndex ? "bg-white w-4" : "bg-white/40"
+                          )} 
+                        />
+                      ))}
+                    </div>
+                  </>
+                )}
+              </>
+            ) : (
+              <div className="flex flex-col items-center justify-center text-slate-500 gap-4">
+                <div className="w-20 h-20 bg-slate-800 rounded-3xl flex items-center justify-center">
+                  {getTypeIcon(report.reportType)}
+                </div>
+                <p className="font-bold text-sm uppercase tracking-widest">No images available</p>
+              </div>
+            )}
+            
+            {/* Quick Actions Overlay */}
+            <div className="absolute top-4 left-4 flex gap-2">
+              <Badge className={cn(
+                "px-3 py-1 rounded-lg uppercase text-[10px] font-black tracking-tight flex items-center gap-1.5 border-2",
+                getTypeStyles(report.reportType)
+              )}>
+                {getTypeIcon(report.reportType)}
+                {report.reportType}
+              </Badge>
+            </div>
+          </div>
+
+          {/* Right Side: Details */}
+          <div className="lg:w-1/2 flex flex-col bg-white">
+            <div className="p-8 flex-1 overflow-y-auto custom-scrollbar">
+              <div className="flex items-center justify-between mb-6">
+                <div className="flex items-center gap-3">
+                  <Avatar 
+                    src={report.user?.profilePicture || undefined} 
+                    className="w-10 h-10 border-2 border-slate-50 text-xs font-black bg-teal-50 text-teal-600"
+                  >
+                    {report.user?.username?.charAt(0).toUpperCase() || 'U'}
+                  </Avatar>
+                  <div className="flex flex-col text-left">
+                    <span className="text-sm font-black text-slate-800">{report.user?.fullName || report.user?.username}</span>
+                    <span className="text-[10px] font-bold text-slate-400 uppercase tracking-tighter">Contributor</span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 text-[10px] text-slate-400 font-bold uppercase tracking-wider">
+                  <Clock size={12} />
+                  {new Date(report.dateCreated).toLocaleDateString()}
+                </div>
+              </div>
+
+              <h2 className="text-3xl font-black text-slate-900 leading-tight mb-4 uppercase italic">
+                {report.title}
+              </h2>
+
+              <div className="space-y-6">
+                <div className="space-y-3">
+                  <h4 className="text-[10px] font-black text-teal-600 uppercase tracking-[0.2em] flex items-center gap-2">
+                    <span className="w-4 h-[2px] bg-teal-600 rounded-full" />
+                    Description
+                  </h4>
+                  <p className="text-slate-600 font-medium leading-relaxed whitespace-pre-wrap">
+                    {report.description}
+                  </p>
+                </div>
+
+                <div className="grid grid-cols-1 gap-4 pt-4">
+                  {report.location && (
+                    <div className="p-4 bg-slate-50 rounded-2xl border border-slate-100">
+                       <h4 className="text-[10px] font-black text-slate-400 uppercase tracking-widest mb-1 flex items-center gap-2">
+                        <MapPin size={12} className="text-teal-600" />
+                        Location
+                      </h4>
+                      <p className="text-sm font-bold text-slate-700">{report.location}</p>
+                    </div>
+                  )}
+                  
+                  {report.contactInfo && (
+                    <div className="p-4 bg-teal-50/50 rounded-2xl border border-teal-100">
+                       <h4 className="text-[10px] font-black text-teal-600 uppercase tracking-widest mb-1 flex items-center gap-2">
+                        <Phone size={12} />
+                        Contact Information
+                      </h4>
+                      <p className="text-sm font-bold text-teal-700">{report.contactInfo}</p>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className="p-8 border-t border-slate-50 flex items-center justify-between bg-white rounded-b-[2.5rem]">
+              <div className="flex items-center gap-6">
+                <button className="flex items-center gap-2 text-slate-400 hover:text-teal-600 transition-colors group">
+                  <Heart size={20} className={cn("group-hover:fill-teal-600 transition-all", report.isReacted && "fill-teal-600 text-teal-600")} />
+                  <span className="text-sm font-black">{report.reactionsCount || 0}</span>
+                </button>
+                <button className="flex items-center gap-2 text-slate-400 hover:text-blue-600 transition-colors group">
+                  <MessageSquare size={20} className="group-hover:fill-blue-600/10 transition-all" />
+                  <span className="text-sm font-black">{report.commentsCount || 0}</span>
+                </button>
+              </div>
+              
+              <div className="flex gap-3">
+                <Button 
+                  variant="outline" 
+                  size="icon" 
+                  className="rounded-xl border-slate-200 hover:bg-slate-50"
+                  onClick={() => {
+                    const url = window.location.href;
+                    navigator.clipboard.writeText(url);
+                  }}
+                >
+                  <Share2 size={18} />
+                </Button>
+                <Button 
+                  onClick={onClose}
+                  className="bg-slate-900 hover:bg-slate-800 text-white font-black px-6 rounded-xl uppercase text-xs tracking-widest"
+                >
+                  Close
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ReportDetailModal;

--- a/src/components/modals/EventAnnouncement/CreateEventAnnouncementModal.tsx
+++ b/src/components/modals/EventAnnouncement/CreateEventAnnouncementModal.tsx
@@ -29,6 +29,8 @@ import {
   MapPin,
   Phone,
   Link as LinkIcon,
+  Shield,
+  Eye,
 } from 'lucide-react';
 import { CommunityService } from '../../../services/communityService';
 
@@ -48,6 +50,7 @@ export interface EventAnnouncementFormData {
   contactInfo?: string;
   reportUrl?: string;
   communityId?: number | string;
+  privacy?: 'community' | 'internal';
 }
 
 export interface CreateEventAnnouncementModalProps {
@@ -57,6 +60,8 @@ export interface CreateEventAnnouncementModalProps {
   type?: ContentType;
   initialData?: Partial<EventAnnouncementFormData>;
   communityId?: number | string;
+  isAdmin?: boolean;
+  isModerator?: boolean;
 }
 
 const INITIAL_FORM_DATA: EventAnnouncementFormData = {
@@ -72,6 +77,7 @@ const INITIAL_FORM_DATA: EventAnnouncementFormData = {
   contactInfo: '',
   reportUrl: '',
   communityId: undefined,
+  privacy: 'community',
 };
 
 const CreateEventAnnouncementModal: React.FC<CreateEventAnnouncementModalProps> = ({
@@ -81,6 +87,8 @@ const CreateEventAnnouncementModal: React.FC<CreateEventAnnouncementModalProps> 
   type = 'announcement',
   initialData,
   communityId,
+  isAdmin = false,
+  isModerator = false,
 }) => {
   const { t } = useTranslation();
   const [formData, setFormData] = useState<EventAnnouncementFormData>(INITIAL_FORM_DATA);
@@ -191,6 +199,7 @@ const CreateEventAnnouncementModal: React.FC<CreateEventAnnouncementModalProps> 
                 toDate: endDateTime, // Modal sends toDate
                 time: formData.time || '00:00',
                 location: formData.location || '',
+                privacy: formData.privacy || 'community',
               }
             ]
           });
@@ -215,6 +224,7 @@ const CreateEventAnnouncementModal: React.FC<CreateEventAnnouncementModalProps> 
             location: formData.location || '',
             contactInfo: formData.contactInfo || '',
             communityId,
+            privacy: formData.privacy || 'community',
           });
 
           if (!result.success) {
@@ -424,6 +434,38 @@ const CreateEventAnnouncementModal: React.FC<CreateEventAnnouncementModalProps> 
               </SelectContent>
             </Select>
           </div>
+
+          {/* Privacy Status Field - Only for admins/moderators */}
+          {(isAdmin || isModerator) && (
+            <div className="mb-6 space-y-2">
+              <label className="block text-sm font-bold text-slate-700 flex items-center gap-2">
+                <Eye className="h-4 w-4 text-teal-600" />
+                Privacy Status <span className="text-red-500">*</span>
+              </label>
+              <Select 
+                value={formData.privacy} 
+                onValueChange={(value: 'community' | 'internal') => handleInputChange('privacy', value)}
+              >
+                <SelectTrigger className="w-full px-4 py-3 border border-slate-200 rounded-2xl focus:outline-none focus:ring-2 focus:ring-teal-500 bg-slate-50 font-medium">
+                  <SelectValue placeholder="Select visibility" />
+                </SelectTrigger>
+                <SelectContent className="rounded-2xl border-slate-200 shadow-lg bg-white">
+                  <SelectItem value="community">
+                    <div className="flex flex-col gap-0.5 text-left">
+                      <span className="font-bold">Community Visibility</span>
+                      <span className="text-[10px] text-slate-500">Visible to all community members</span>
+                    </div>
+                  </SelectItem>
+                  <SelectItem value="internal">
+                    <div className="flex flex-col gap-0.5 text-left">
+                      <span className="font-bold">Internal Only</span>
+                      <span className="text-[10px] text-slate-500">Only visible to community admins and moderators</span>
+                    </div>
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          )}
 
           {/* Location Field */}
           <div className="mb-6 space-y-2">

--- a/src/components/modals/ReportModal/CreateReportModal.tsx
+++ b/src/components/modals/ReportModal/CreateReportModal.tsx
@@ -24,9 +24,11 @@ import {
   DollarSign, 
   Phone, 
   ShieldCheck, 
+  Shield,
   Camera, 
   Upload, 
-  X
+  X,
+  Eye
 } from 'lucide-react';
 import { useAuth } from '../../../context/AuthContext';
 import { Modal } from '../../ui/Modal/Modal';
@@ -68,7 +70,7 @@ export const CreateReportModal: React.FC<CreateReportModalProps> = ({
     location: '',
     contactInfo: '',
     rewardDetails: '',
-    reportType: initialType || (isCommunityContext ? 'News' : 'Lost')
+    reportType: initialType || (isCommunityContext ? 'News' : 'Lost'),
   });
 
   const [images, setImages] = useState<string[]>([]);
@@ -235,7 +237,7 @@ export const CreateReportModal: React.FC<CreateReportModalProps> = ({
         location: '',
         contactInfo: '',
         rewardDetails: '',
-        reportType: 'Lost'
+        reportType: 'Lost',
       });
       setImages([]);
       setImageFiles([]);

--- a/src/components/modals/index.tsx
+++ b/src/components/modals/index.tsx
@@ -17,4 +17,5 @@ export type { EventAnnouncementFormData, ContentType, CreateEventAnnouncementMod
 export { default as CreateCalendarModal } from './Calendar/CreateCalendarModal';
 export type { CreateCalendarFormData, CalendarEntry, CreateCalendarModalProps } from './Calendar/CreateCalendarModal';
 export { default as CommunityReportModal } from './CommunityReport/CommunityReportModal';
+export { default as ReportDetailModal } from './CommunityReport/ReportDetailModal';
 export type { CommunityReportPayload, CommunityReportResponse } from '@/services/communityReportService';

--- a/src/components/pages/public/CommunityPage/CommunityPage.tsx
+++ b/src/components/pages/public/CommunityPage/CommunityPage.tsx
@@ -127,6 +127,7 @@ const CommunityPage: React.FC = () => {
               toDate: entry.toDate,
               time: entry.time || '00:00',
               location: entry.location || '',
+              privacy: entry.privacy || 'community',
             };
           }),
         };
@@ -240,6 +241,7 @@ const CommunityPage: React.FC = () => {
             posts={posts || []} 
             isMember={isMember}
             isAdmin={community.isAdmin}
+            isModerator={isModerator}
             onRefresh={refresh}
           />
         );
@@ -315,6 +317,8 @@ const CommunityPage: React.FC = () => {
               onClose={() => setIsUpdatesModalOpen(false)}
               type={isUpdatesModalType}
               communityId={community?.id}
+              isAdmin={isAdmin}
+              isModerator={isModerator}
               onSuccess={(data) => {
                 if (isUpdatesModalType === 'announcement') handleAnnouncementSuccess(data);
                 else if (isUpdatesModalType === 'news') handleNewsSuccess(data);
@@ -327,6 +331,8 @@ const CommunityPage: React.FC = () => {
               isOpen={isCalendarModalOpen}
               onClose={() => setIsCalendarModalOpen(false)}
               type={calendarModalType}
+              isAdmin={isAdmin}
+              isModerator={isModerator}
               onSuccess={handleCalendarSuccess}
             />
           </>
@@ -473,7 +479,7 @@ const CommunityPage: React.FC = () => {
         </div>
       </div>
 
-      <div className="w-full px-4 md:px-6 lg:px-8 py-2 md:pt-4 flex-1 lg:h-full lg:overflow-hidden min-h-0">
+      <div className="w-full px-4 md:px-6 lg:px-8 py-2 lg:pt-32 flex-1 lg:h-full lg:overflow-hidden min-h-0">
         <main className="w-full h-full grid grid-cols-1 lg:grid-cols-10 gap-6 lg:overflow-hidden">
         {/* --- LEFT SIDEBAR: SHARED NAVIGATION --- */}
         <div className="order-2 lg:order-1 lg:col-span-2 lg:h-full lg:overflow-y-auto lg:overflow-x-hidden scrollbar-hidden hover:custom-scrollbar transition-all pt-2 pb-6 min-w-0">
@@ -805,12 +811,8 @@ const CommunityPage: React.FC = () => {
         onSuccess={handleCommunityReportSuccess}
         communityId={id || ''}
         reportType={communityReportType}
-      />
-
-      <ModerationOverviewModal 
-        isOpen={isModerationOpen}
-        onClose={() => setIsModerationOpen(false)}
-        communityId={id}
+        isAdmin={isAdmin}
+        isModerator={isModerator}
       />
     </div>
   );

--- a/src/components/pages/public/NewsFeedPage/components/CommunitySidebar.tsx
+++ b/src/components/pages/public/NewsFeedPage/components/CommunitySidebar.tsx
@@ -138,7 +138,7 @@ const CommunitySidebar: React.FC<CommunitySidebarProps> = ({
   }, {} as Record<string, typeof relevantEvents>);
 
   return (
-    <aside className={cn("flex flex-col space-y-4 pt-6 group h-fit", className)}>
+    <aside className={cn("flex flex-col space-y-4 pt-6in group h-fit", className)}>
       {/* JOIN THE ACTION SECTION */}
       <div className="space-y-3">
         <div className="bg-white rounded-[2rem] py-5 px-8 shadow-sm border border-gray-50 flex items-center justify-between group/pill cursor-pointer hover:shadow-md transition-all">

--- a/src/hooks/useCommunities.ts
+++ b/src/hooks/useCommunities.ts
@@ -64,9 +64,11 @@ export const useCommunityDetail = (id: string | undefined) => {
       }
 
       setCommunity(updatedCommunity);
-      // Filter for active posts by default
+      // Filter for active posts by default - handle case-insensitivity for 'Active'/'active'
       const activePosts = Array.isArray(postsData) 
-        ? postsData.filter((post: CommunityPost) => post.status === 'active')
+        ? postsData.filter((post: CommunityPost) => 
+            String(post.status).toLowerCase() === 'active'
+          )
         : [];
       setPosts(activePosts);
       setMembers(Array.isArray(membersData) ? membersData : []);

--- a/src/services/communityReportService.ts
+++ b/src/services/communityReportService.ts
@@ -11,6 +11,7 @@ export interface CommunityReportPayload {
   location: string;
   contactInfo: string;
   communityId: number | string;
+  privacy?: 'community' | 'internal';
 }
 
 export interface CommunityReportResponse {
@@ -25,6 +26,7 @@ export interface CommunityReportResponse {
   location: string;
   contactInfo: string;
   communityId: number;
+  privacy?: 'community' | 'internal';
   createdAt: string;
   createdBy?: {
     id: string;

--- a/src/types/community.ts
+++ b/src/types/community.ts
@@ -48,6 +48,7 @@ export interface CommunityPost {
   location: string;
   contactInfo: string;
   rewardDetails: string | null;
+  privacy?: 'community' | 'internal';
   categoryId: number | null;
   categoryName: string | null;
   communityId: number;
@@ -136,6 +137,7 @@ export interface CalendarEvent {
   endDate: string;  // ISO 8601 format: 2026-01-20T08:07:34.119Z
   time?: string; // Time in HH:mm format
   location: string;
+  privacy?: 'community' | 'internal';
 }
 
 export interface CreateCalendarPayload {


### PR DESCRIPTION
- Introduced privacy options ('community' and 'internal') in Event Announcement and Report Modals.
- Updated CreateEventAnnouncementModal to include privacy selection for admins and moderators.
- Enhanced CommunityPage and related components to filter announcements and events based on privacy settings.
- Implemented ReportDetailModal to view details of reports with privacy indicators.
- Adjusted CommunityFeed and CommunityNews components to handle privacy logic and display accordingly.
- Updated community services and types to support new privacy fields.