### PR TITLE
Add mobile app download link and update Play Store URL in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ FindrHub is a React-based platform focused on helping communities reunite lost i
 
 The app is configured for deployment on Vercel. Simply connect your repository to Vercel and it will automatically deploy using the `vercel.json` configuration.
 
+## Mobile App
+
+Download FindrHub mobile app (APK):
+- [FindrHub APK](https://expo.dev/accounts/olabrada/projects/findrhub/builds/837d6dae-dc84-46c1-9bfa-cda3605edc00)
+
 ## Security
 
 - **CSP**: Content Security Policy implemented in `index.html`.

--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-f87553f6'], (function (workbox) { 'use strict';
     "revision": "d41d8cd98f00b204e9800998ecf8427e"
   }, {
     "url": "index.html",
-    "revision": "0.4hdn51eli28"
+    "revision": "0.duoi7kaut3g"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/constants/appStoreConfig.ts
+++ b/src/constants/appStoreConfig.ts
@@ -15,7 +15,7 @@ export const APP_STORE_CONFIG = {
     
     // Google Play Store
     android: {
-      url: 'https://play.google.com/store/apps/details?id=com.findrhub.app',
+      url: 'https://expo.dev/accounts/olabrada/projects/findrhub/builds/837d6dae-dc84-46c1-9bfa-cda3605edc00',
       packageName: 'com.findrhub.app',
       name: 'FindrHub',
     },


### PR DESCRIPTION
Add a link to download the FindrHub mobile app and update the Play Store URL in the documentation to point to the correct APK.